### PR TITLE
include stdint.h

### DIFF
--- a/AStar.c
+++ b/AStar.c
@@ -30,6 +30,7 @@
 #include "AStar.h"
 #include <math.h>
 #include <string.h>
+#include <stdint.h>
 
 struct __ASNeighborList {
     const ASPathNodeSource *source;


### PR DESCRIPTION
it's necessary to get int8_t prototype on systems which care about namespace cleanness.